### PR TITLE
add trailing slash to contact link in header menu

### DIFF
--- a/source/layouts/_header.slim
+++ b/source/layouts/_header.slim
@@ -20,4 +20,4 @@ nav.navbar.navbar-expand-md.navbar-light.border.border-primary.border-top-0.bord
       // li.nav-item
       //   = link_to 'Factory', '/' ,class: 'nav-link'
       li.nav-item
-        = link_to 'Contact', '/contact' ,class: 'nav-link'
+        = link_to 'Contact', '/contact/' ,class: 'nav-link'


### PR DESCRIPTION
add trainling slash to contact link in header menu for testing purpposes to fix error caused by instant-page js library prefetch