### PR TITLE
add data-no-instant attribute to vintage posters link in header menu

### DIFF
--- a/source/layouts/_header.slim
+++ b/source/layouts/_header.slim
@@ -14,7 +14,7 @@ nav.navbar.navbar-expand-md.navbar-light.border.border-primary.border-top-0.bord
       li.nav-item
         = link_to 'Videos', '/videos' ,class: 'nav-link'
       li.nav-item
-        = link_to 'Posters', '/vintage-posters' ,class: 'nav-link'
+        = link_to 'Posters', '/vintage-posters' ,class: 'nav-link', :"data-no-instant" => true
       li.nav-item
         = link_to 'History timeline', '/history-timeline' ,class: 'nav-link'
       // li.nav-item


### PR DESCRIPTION
add data-no-instant attiribute to vintage posters link in header menu to prevent page frefetching as it breaks infinite loading onvintage posters page